### PR TITLE
Convert "Extract All" to Bulk Extract

### DIFF
--- a/Obsidian/MVVM/ModelViews/Dialogs/ExtractOperationDialog.xaml.cs
+++ b/Obsidian/MVVM/ModelViews/Dialogs/ExtractOperationDialog.xaml.cs
@@ -114,10 +114,17 @@ namespace Obsidian.MVVM.ModelViews.Dialogs
 
                 this.Message = entry.Path;
 
-                using Stream entryStream = entry.Entry.GetDataHandle().GetDecompressedStream();
-                using FileStream entryFileStream = File.OpenWrite(path);
+                try
+                {
+                    using Stream entryStream = entry.Entry.GetDataHandle().GetDecompressedStream();
+                    using FileStream entryFileStream = File.OpenWrite(path);
 
-                entryStream.CopyTo(entryFileStream);
+                    entryStream.CopyTo(entryFileStream);
+                } catch(Exception)
+                {
+
+                }
+
 
                 progress += 1;
                 (e.Argument as BackgroundWorker).ReportProgress((int)progress);

--- a/Obsidian/MainWindow.xaml.cs
+++ b/Obsidian/MainWindow.xaml.cs
@@ -468,6 +468,26 @@ namespace Obsidian
             }
         }
 
+        private List<WadFileViewModel> getAllChampionFiles()
+        {
+
+            IEnumerator<WadViewModel> collection = WadViewModels.GetEnumerator();
+            List<WadFileViewModel> result = new();
+
+            while (collection.MoveNext())
+            {
+                WadViewModel current = collection.Current;
+                IEnumerable<WadFileViewModel> files = current.GetAllFiles();
+
+                foreach (WadFileViewModel file in files)
+                {
+                    result.Add(file);
+                }
+            }
+
+            return result;
+        }
+
         private async void ExtractAll()
         {
             using CommonOpenFileDialog dialog = new CommonOpenFileDialog
@@ -478,9 +498,10 @@ namespace Obsidian
 
             if (dialog.ShowDialog() == CommonFileDialogResult.Ok)
             {
-                await DialogHelper.ShowExtractOperationDialog(dialog.FileName, this.SelectedWad.GetAllFiles());
+                await DialogHelper.ShowExtractOperationDialog(dialog.FileName, this.getAllChampionFiles());
             }
         }
+
         private async void ExtractSelected()
         {
             using CommonOpenFileDialog dialog = new CommonOpenFileDialog


### PR DESCRIPTION
### Background
It would be useful if the `Extract All` option allowed for bulk extracting. In it's current state, `Extract All` only extracts the current WAD file in the user's tab view.

### Summary
Add `getAllChampionFiles()`. `Extract All` option will now convert all open WAD files (allows for bulk extract).

### Demo

https://user-images.githubusercontent.com/11217803/147041930-d63e399c-42cf-4560-9469-bdb8255b204d.mp4


