### PR TITLE
Fix potential wad parsing failures

### DIFF
--- a/Obsidian/Data/Wad/WadTreeModel.cs
+++ b/Obsidian/Data/Wad/WadTreeModel.cs
@@ -79,7 +79,7 @@ public class WadTreeModel : IWadTreeParent, IDisposable
             string path = this.Hashtable.TryGetChunkPath(chunk, out path) switch
             {
                 true => path,
-                false => this.Hashtable.GuessChunkPath(chunk, wad),
+                false => HashtableService.GuessChunkPath(chunk, wad),
             };
 
             this.AddWadFile(wadFilePathComponents.Concat(path.Split('/')), wad, chunk);

--- a/Obsidian/Pages/ExplorerPage.razor.cs
+++ b/Obsidian/Pages/ExplorerPage.razor.cs
@@ -51,7 +51,7 @@ public partial class ExplorerPage
                                         "*.*",
                                         SearchOption.AllDirectories
                                     )
-                                    .Where(x => x.Contains(".wad"))
+                                    .Where(x => x.EndsWith(".wad") || x.EndsWith(".wad.client"))
                             )
                     };
                 });

--- a/Obsidian/Services/HashtableService.cs
+++ b/Obsidian/Services/HashtableService.cs
@@ -242,20 +242,25 @@ public class HashtableService
     public bool TryGetChunkPath(WadChunk chunk, out string path) =>
         this.Hashes.TryGetValue(chunk.PathHash, out path);
 
-    public string GuessChunkPath(WadChunk chunk, WadFile wad)
+    public static string GuessChunkPath(WadChunk chunk, WadFile wad)
     {
-        string extension = null;
-        if (chunk.Compression is not WadChunkCompression.Satellite)
+        string extension = chunk.Compression switch
         {
-            using Stream stream = wad.LoadChunkDecompressed(chunk).AsStream();
-
-            extension = LeagueFile.GetExtension(LeagueFile.GetFileType(stream));
-        }
+            WadChunkCompression.Satellite => null,
+            _ => GuessChunkExtension(chunk, wad)
+        };
 
         return string.IsNullOrEmpty(extension) switch
         {
             true => string.Format("{0:x16}", chunk.PathHash),
             false => string.Format("{0:x16}.{1}", chunk.PathHash, extension),
         };
+
+        static string GuessChunkExtension(WadChunk chunk, WadFile wad)
+        {
+            using Stream stream = wad.LoadChunkDecompressed(chunk).AsStream();
+
+            return LeagueFile.GetExtension(LeagueFile.GetFileType(stream));
+        }
     }
 }

--- a/Obsidian/Services/HashtableService.cs
+++ b/Obsidian/Services/HashtableService.cs
@@ -244,9 +244,13 @@ public class HashtableService
 
     public string GuessChunkPath(WadChunk chunk, WadFile wad)
     {
-        using Stream stream = wad.LoadChunkDecompressed(chunk).AsStream();
+        string extension = null;
+        if (chunk.Compression is not WadChunkCompression.Satellite)
+        {
+            using Stream stream = wad.LoadChunkDecompressed(chunk).AsStream();
 
-        string extension = LeagueFile.GetExtension(LeagueFile.GetFileType(stream));
+            extension = LeagueFile.GetExtension(LeagueFile.GetFileType(stream));
+        }
 
         return string.IsNullOrEmpty(extension) switch
         {


### PR DESCRIPTION
This fixes two potential failure scenarios:
1. The game path contains files which have `.wad` in their path but aren't actually wad files. For safety and potential future-proofness I've hardcoded the two known file extensions `.wad` and `.wad.client` to be checked instead.
2. Opening a wad file that contains satellite chunks that do not have a resolved path in the hashtable throws an error and fails to open the wad file. I've fixed this by checking for `WadChunkCompression.Satellite` in `GuessChunkPath`.