### PR TITLE
Allow duplicate elements in wad view, fix sorting not applying when loading wads manually

### DIFF
--- a/Obsidian/Data/Wad/IWadTreeParent.cs
+++ b/Obsidian/Data/Wad/IWadTreeParent.cs
@@ -4,7 +4,7 @@ using System.Text.RegularExpressions;
 namespace Obsidian.Data.Wad;
 
 public interface IWadTreeParent : IWadTreePathable {
-    Dictionary<string, WadTreeItemModel> Items { get; }
+    List<WadTreeItemModel> Items { get; }
 }
 
 public static class IWadTreeParentExtensions {
@@ -17,17 +17,17 @@ public static class IWadTreeParentExtensions {
         // File belongs to this folder
         if (pathComponents.Count() is 1) {
             string name = pathComponents.First();
-            parent.Items.Add(name, new WadTreeFileModel(parent, name, wad, chunk));
+            parent.Items.Add(new WadTreeFileModel(parent, name, wad, chunk));
             return;
         }
 
         string folderName = pathComponents.First();
         WadTreeItemModel directory = null;
         lock (parent) {
-            directory = parent.Items.GetValueOrDefault(folderName);
+            directory = parent.Items.FirstOrDefault(item => item.Name == folderName && item is not WadTreeFileModel);
             if (directory is null) {
                 directory = new(parent, folderName);
-                parent.Items.Add(directory.Name, directory);
+                parent.Items.Add(directory);
             }
         }
 
@@ -38,7 +38,7 @@ public static class IWadTreeParentExtensions {
         if (parent.Items is null)
             yield break;
 
-        foreach (var (_, item) in parent.Items) {
+        foreach (var item in parent.Items) {
             yield return item;
 
             foreach (WadTreeItemModel itemItem in item.TraverseFlattenedItems())
@@ -52,7 +52,7 @@ public static class IWadTreeParentExtensions {
         if (parent.Items is null)
             yield break;
 
-        foreach (var (_, item) in parent.Items) {
+        foreach (var item in parent.Items) {
             if (item.IsChecked)
                 yield return item;
 
@@ -69,7 +69,7 @@ public static class IWadTreeParentExtensions {
         if (parent.Items is null)
             yield break;
 
-        foreach (var (_, item) in parent.Items) {
+        foreach (var item in parent.Items) {
             if (!string.IsNullOrEmpty(filter)) {
                 // If the current item is a file we check if it matches the filter
                 if (item is WadTreeFileModel && DoesMatchFilter(item, filter, useRegex)) {
@@ -78,12 +78,12 @@ public static class IWadTreeParentExtensions {
                 }
 
                 // If the current item is a folder we get filtered items and if there are none we skip
-                IReadOnlyList<WadTreeItemModel> filteredItems = item.TraverseFlattenedVisibleItems(
+                WadTreeItemModel[] filteredItems = item.TraverseFlattenedVisibleItems(
                         filter,
                         useRegex
                     )
-                    .ToList();
-                if (filteredItems.Count is 0)
+                    .ToArray();
+                if (filteredItems.Length is 0)
                     continue;
 
                 // Return parent only if its children are included in the filter

--- a/Obsidian/Data/Wad/WadTreeItemModel.cs
+++ b/Obsidian/Data/Wad/WadTreeItemModel.cs
@@ -23,7 +23,19 @@ public class WadTreeItemModel
     public int Depth => this.GetDepth();
 
     public Guid Id { get; } = Guid.NewGuid();
-    public string Name { get; set; }
+
+    private string _name;
+    public string Name {
+        get => this._name;
+        set {
+            this._name = value;
+
+            this.IsWadArchive = this._name.EndsWith(".wad", StringComparison.OrdinalIgnoreCase)
+                                || this._name.EndsWith(".wad.client", StringComparison.OrdinalIgnoreCase)
+                                || this._name.EndsWith(".wad.mobile", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
     public string Path { get; }
 
     public string Icon => GetIcon();
@@ -34,17 +46,9 @@ public class WadTreeItemModel
     public bool IsChecked { get; set; }
     public bool IsExpanded { get; set; }
 
-    public Dictionary<string, WadTreeItemModel> Items { get; protected set; } = new();
+    public List<WadTreeItemModel> Items { get; protected set; } = new();
 
-    public bool IsWadArchive {
-        get {
-            string extension = PathIO.GetExtension(this.Name);
-
-            return extension.Contains("wad")
-                || extension.Contains("client")
-                || extension.Contains("server");
-        }
-    }
+    public bool IsWadArchive { get; private set; }
 
     public WadTreeItemModel(IWadTreeParent parent, string name) {
         this.Parent = parent;
@@ -60,11 +64,10 @@ public class WadTreeItemModel
         if (this.Items is null)
             return;
 
-        this.Items = new(this.Items.OrderBy(x => x.Value));
+        this.Items.Sort();
 
-        foreach (var (_, item) in this.Items) {
-            if (item.Type is WadTreeItemType.Directory)
-                item.SortItems();
+        foreach (WadTreeItemModel item in this.Items.Where(item => item.Type is WadTreeItemType.Directory)) {
+            item.SortItems();
         }
     }
 

--- a/Obsidian/Shared/TreeWadItem.razor.cs
+++ b/Obsidian/Shared/TreeWadItem.razor.cs
@@ -152,7 +152,7 @@ public partial class TreeWadItem {
     }
 
     private void Delete() {
-        this.Item.Parent.Items.Remove(this.Item.Name);
+        this.Item.Parent.Items.Remove(this.Item);
         this.Explorer.RefreshState();
     }
 }

--- a/Obsidian/Shared/WadExplorer.razor.cs
+++ b/Obsidian/Shared/WadExplorer.razor.cs
@@ -91,7 +91,7 @@ public partial class WadExplorer : IDisposable {
                     FileStream wadFileStream = File.OpenRead(wadPath);
                     WadFile wad = new(wadFileStream);
 
-                    this.WadTree.CreateTreeForWadFile(wad, Path.GetFileName(wadPath));
+                    this.WadTree.CreateTreeForWadFile(wad, Path.GetFileName(wadPath), true);
                 }
             });
 
@@ -100,6 +100,7 @@ public partial class WadExplorer : IDisposable {
             SnackbarUtils.ShowHardError(this.Snackbar, exception);
         } finally {
             this._isLoadingWadFile = false;
+            this.WadTree.SortItems();
             StateHasChanged();
         }
     }
@@ -191,15 +192,15 @@ public partial class WadExplorer : IDisposable {
             );
     }
 
-    public List<WadTreeItemModel> GetVisibleItemsForWadTree() {
+    private ICollection<WadTreeItemModel> GetVisibleItemsForWadTree() {
         try {
             return this.WadTree
                 .TraverseFlattenedVisibleItems(this.WadTree.Filter, this.WadTree.UseRegexFilter)
-                .ToList();
+                .ToArray();
         } catch (Exception exception) {
             SnackbarUtils.ShowSoftError(this.Snackbar, exception);
 
-            return new();
+            return Array.Empty<WadTreeItemModel>();
         }
     }
 


### PR DESCRIPTION
Before: 
![image](https://github.com/Crauzer/Obsidian/assets/35152647/2e61c10b-3460-47f9-827f-b5e5b5a2d0d0)

After: 
![image](https://github.com/Crauzer/Obsidian/assets/35152647/4cefa458-09c1-48e2-be29-85f0b284a90f)

I've changed `Dictionary` to `List` because `Dictionary` *technically* does not guarantee ordering, even if it happened to work. Also, this allows having multiple elements with the same name / key, which can be useful for e.g. loading multiple versions of `Global.wad.client` side-by-side.
This also fixes the rare issue where wad files failed to fully load when a file has a name that is equal to an existing folder name; for example in `Global.wad.client`: `loadouts/tftdamageskins/abyssalchasm.vfxdefinition.bin` conflicts with `loadouts/tftdamageskins`.

- **Q**: How will this work with extracting?
- **A**: idk lol