### PR TITLE
Fix incorrect fallback texture being passed to CreateMaterialTextureImageBlob

### DIFF
--- a/Obsidian/Utils/SkinnedMeshUtils.cs
+++ b/Obsidian/Utils/SkinnedMeshUtils.cs
@@ -63,7 +63,7 @@ public static class SkinnedMeshUtils
 
             textures[materialOverride.Submesh] = await CreateMaterialTextureImageBlob(
                 materialOverride.Material,
-                defaultTexture,
+                meshData.Texture,
                 skinPackage,
                 wad,
                 metaEnvironment,


### PR DESCRIPTION
I don't quite understand the logic in that function but the previous value being passed was nonsense.

This fixes some skins not being viewable as [reported on Discord](https://discord.com/channels/320848982400040960/611554676219052042/1117214868760698900).