### PR TITLE
Fix exception when fallbackTexture is empty

### DIFF
--- a/Obsidian/Utils/SkinnedMeshUtils.cs
+++ b/Obsidian/Utils/SkinnedMeshUtils.cs
@@ -79,8 +79,12 @@ public static class SkinnedMeshUtils {
         IJSRuntime js
     ) {
         BinTreeObject materialDefObject = skinPackage.Objects.GetValueOrDefault(materialLink);
-        if (materialDefObject is null)
-            return await ImageUtils.CreateImageBlobFromChunk(js, fallbackTexture, wad);
+        if (materialDefObject is null) {
+            return string.IsNullOrEmpty(fallbackTexture) switch {
+                true => fallbackTexture,
+                _ => await ImageUtils.CreateImageBlobFromChunk(js, fallbackTexture, wad)
+            };
+        }
 
         var materialDef = MetaSerializer.Deserialize<StaticMaterialDef>(
             metaEnvironment,


### PR DESCRIPTION
Follow-up to #197; apparently some skins do not provide a default texture at all and instead all submeshes have their own override. The code did not expect that and threw an exception when trying to load a chunk with empty path from the wad.

That can be avoided by just not doing it. Each submesh has its own texture specified, so a valid fallback texture isn't necessary.

An example would be morgana skin60.