### PR TITLE
Reduce github api calls in hashtable syncing from 2 to 1

### DIFF
--- a/Obsidian/Services/HashtableService.cs
+++ b/Obsidian/Services/HashtableService.cs
@@ -36,6 +36,8 @@ public class HashtableService {
     private const string BIN_HASHES_PATH = "hashes/hashes.binhashes.txt";
     private const string BIN_OBJECTS_PATH = "hashes/hashes.binentries.txt";
 
+    private IReadOnlyList<RepositoryContent> cdragonRepositoryContent;
+
     public HashtableService(Config config) {
         this.Config = config;
     }
@@ -83,14 +85,14 @@ public class HashtableService {
         Log.Information("Syncing WAD hashtables");
 
         GitHubClient github = new(new ProductHeaderValue("Obsidian"));
-        IReadOnlyList<RepositoryContent> content = await github.Repository.Content.GetAllContents(
+        this.cdragonRepositoryContent ??= await github.Repository.Content.GetAllContents(
             "CommunityDragon",
             "CDTB",
             "cdragontoolbox"
         );
 
-        RepositoryContent gameHashesContent = GetRepositoryContent(content, "hashes.game.txt");
-        RepositoryContent lcuHashesContent = GetRepositoryContent(content, "hashes.lcu.txt");
+        RepositoryContent gameHashesContent = GetRepositoryContent(this.cdragonRepositoryContent, "hashes.game.txt");
+        RepositoryContent lcuHashesContent = GetRepositoryContent(this.cdragonRepositoryContent, "hashes.lcu.txt");
 
         this.Config.GameHashesChecksum = await SyncHashtable(
             client,
@@ -112,16 +114,16 @@ public class HashtableService {
         Log.Information("Syncing BIN hashtables");
 
         GitHubClient github = new(new ProductHeaderValue("Obsidian"));
-        IReadOnlyList<RepositoryContent> content = await github.Repository.Content.GetAllContents(
+        this.cdragonRepositoryContent ??= await github.Repository.Content.GetAllContents(
             "CommunityDragon",
             "CDTB",
             "cdragontoolbox"
         );
 
-        RepositoryContent fieldsContent = GetRepositoryContent(content, "hashes.binfields.txt");
-        RepositoryContent typesContent = GetRepositoryContent(content, "hashes.bintypes.txt");
-        RepositoryContent hashesContent = GetRepositoryContent(content, "hashes.binhashes.txt");
-        RepositoryContent entriesContent = GetRepositoryContent(content, "hashes.binentries.txt");
+        RepositoryContent fieldsContent = GetRepositoryContent(this.cdragonRepositoryContent, "hashes.binfields.txt");
+        RepositoryContent typesContent = GetRepositoryContent(this.cdragonRepositoryContent, "hashes.bintypes.txt");
+        RepositoryContent hashesContent = GetRepositoryContent(this.cdragonRepositoryContent, "hashes.binhashes.txt");
+        RepositoryContent entriesContent = GetRepositoryContent(this.cdragonRepositoryContent, "hashes.binentries.txt");
 
         this.Config.BinFieldsHashesChecksum = await SyncHashtable(
             client,


### PR DESCRIPTION
By default, Octokit only gets 60 api calls per hour, which is pretty low, especially considering Obsidian can do up to 3 api calls on startup (2 for hashtable syncing, 1 for self update check). I have hit this myself when doing testing and could imagine other people hitting it, so here's a free optimization that merges both hashtable api calls into one.

Not entirely happy with this being a class field but this is all only called once anyway, so I don't think doing anything advanced is necessary here.