### PR TITLE
Optimize hashtable loading

### DIFF
--- a/Obsidian/Services/HashtableService.cs
+++ b/Obsidian/Services/HashtableService.cs
@@ -178,34 +178,25 @@ public class HashtableService {
 
     public void LoadHashtable(string hashtablePath) {
         using StreamReader reader = new(hashtablePath);
-        StringBuilder nameBuilder = new();
 
-        while (reader.EndOfStream is false) {
-            string line = reader.ReadLine();
-            string[] split = line.Split(' ');
-
-            ulong pathHash = ulong.Parse(split[0], NumberStyles.HexNumber);
-            nameBuilder = nameBuilder.AppendJoin(' ', split.Skip(1));
-
-            this.Hashes.TryAdd(pathHash, nameBuilder.ToString());
-
-            nameBuilder.Clear();
+        while (reader.ReadLine() is string line) {
+            var separatorIndex = line.IndexOf(' ');
+        
+            ulong pathHash = ulong.Parse(line.AsSpan(0, separatorIndex), NumberStyles.HexNumber);
+        
+            this.Hashes.TryAdd(pathHash, line[(separatorIndex+1)..]);
         }
     }
 
     private static void LoadBinHashtable(string hashtablePath, Dictionary<uint, string> hashtable) {
         using StreamReader reader = new(hashtablePath);
-        StringBuilder nameBuilder = new();
 
-        while (reader.EndOfStream is false) {
-            string line = reader.ReadLine();
-            string[] split = line.Split(' ');
+        while (reader.ReadLine() is string line) {
+            string[] split = line.Split(' ', 2);
 
             uint hash = uint.Parse(split[0], NumberStyles.HexNumber);
-            nameBuilder = nameBuilder.AppendJoin(' ', split.Skip(1));
 
-            hashtable.TryAdd(hash, nameBuilder.ToString());
-            nameBuilder.Clear();
+            hashtable.TryAdd(hash, split[1]);
         }
     }
 


### PR DESCRIPTION
Just a bit of free optimization for the hashtable loading, as that does take a significant amount of time, mainly loading `hashes.game.txt`.

In my basic testing, this reduces loading time of the `hashes.game.txt` file from ~1.5s to ~1.2s, while also reducing total memory allocations from ~920MB to ~600MB.

I've used two different methods here, a more readable and simple and slightly less optimal for bin hashtable loading, and a more optimized one for game/lcu hashtable loading.