### PR TITLE
Fix the taskbar icon potentially missing

### DIFF
--- a/Obsidian/Program.cs
+++ b/Obsidian/Program.cs
@@ -55,9 +55,10 @@ public class Program {
         app.MainWindow.UseOsDefaultSize = false;
         app.MainWindow
             .SetIconFile("favicon.ico")
-            .SetTitle("Obsidian")
+            .SetTitle(string.Empty)
             .SetUseOsDefaultSize(true)
             .SetContextMenuEnabled(false)
+            .RegisterWindowCreatedHandler(WindowCreatedHandler)
             .RegisterApi(new());
 
         app.MainWindow.SetDevToolsEnabled(true);
@@ -82,5 +83,13 @@ public class Program {
                 outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {Message:lj}{NewLine}{Exception}"
             )
             .CreateLogger();
+    }
+
+    // used to workaround issues with the taskbar icon going missing, see also
+    // https://github.com/tryphotino/photino.NET/issues/106 and
+    // https://github.com/tryphotino/photino.NET/issues/85
+    private static void WindowCreatedHandler(object sender, EventArgs e)
+    {
+        ((PhotinoNET.PhotinoWindow)sender).SetTitle("Obsidian");
     }
 }


### PR DESCRIPTION
This seems to be an issue on Photino's end, where the way the window is constructed can lead to the taskbar icon going missing.
This also prevents an Obsidian shortcut being created in the startmenu on every build, which was annoying me at the very least.

I personally had this issue and have also seen it get reported in passing on discord, so I'd rather workaround this issue than wait for upstream to fix it. See also the inline comments for more context.